### PR TITLE
update deadpool to 0.8, ldap3 to 0.9, tokio to 1, and actix_rt to 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "deadpool-ldap"
-version = "0.1.3"
+version = "0.2.0"
 authors = ["Aitor Ruano <codearm@pm.me>"]
 edition = "2018"
 license = "MIT/Apache-2.0"
@@ -11,10 +11,10 @@ keywords = ["ldap", "ldap3", "deadpool", "pool", "async"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ldap3 = { version = "0.7", default-features = false }
-deadpool = { version = "0.6", default-features = false, features = ["managed"] }
-actix-rt = { version = "1", optional = true }
-tokio = { version = "0.2", optional = true }
+ldap3 = { version = "0.9", default-features = false }
+deadpool = { version = "0.8", default-features = false, features = ["managed"] }
+actix-rt = { version = "2", optional = true }
+tokio = { version = "1", features = ["rt"], optional = true }
 async-trait = "0.1"
 log = "0.4"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,17 @@
 pub mod errors;
 
 use async_trait::async_trait;
-use ldap3::{exop::WhoAmI, Ldap, LdapConnAsync, LdapError as Error};
+use ldap3::{exop::WhoAmI, Ldap, LdapConnAsync, LdapError};
 
 pub type Pool = deadpool::managed::Pool<Ldap, errors::LdapError>;
 pub struct Manager(pub &'static str);
 
 #[async_trait]
-impl deadpool::managed::Manager<Ldap, Error> for Manager {
-    async fn create(&self) -> Result<Ldap, Error> {
+impl deadpool::managed::Manager for Manager {
+    type Type = Ldap;
+    type Error = LdapError;
+
+    async fn create(&self) -> Result<Self::Type, Self::Error> {
         let (conn, ldap) = LdapConnAsync::new(self.0).await?;
         #[cfg(feature = "default")]
         ldap3::drive!(conn);
@@ -20,7 +23,7 @@ impl deadpool::managed::Manager<Ldap, Error> for Manager {
         });
         Ok(ldap)
     }
-    async fn recycle(&self, conn: &mut Ldap) -> deadpool::managed::RecycleResult<Error> {
+    async fn recycle(&self, conn: &mut Self::Type) -> deadpool::managed::RecycleResult<Self::Error> {
         conn.extended(WhoAmI).await?;
         Ok(())
     }


### PR DESCRIPTION
This allows this crate to be used against newer versions of these other crates (which are all updated to support tokio 1.x)